### PR TITLE
Add SpaceONE Labeling

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -14,14 +14,14 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 1.1.0
 
-dependencies:
-  - name: vault
-    version: 0.5.0
-    repository: https://helm.releases.hashicorp.com
+#dependencies:
+#  - name: vault
+#    version: 0.5.0
+#    repository: https://helm.releases.hashicorp.com
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Manage your infrastructure with SpaceONE. It doesn't matter what your infrastruc
 
 ### Commands
 
-> ⚠️  `inventory-scheduler` and `statistics-scheduler` doesn't work fine until you execute `initialize-spaceone` which is a Kubernetes `Job`. Please create the `Job` after reading the following commands.
+> ⚠️  `inventory-scheduler` and `statistics-scheduler` doesn't work fine until you execute `initialize-spaceone` which is a Kubernetes `Job`. Please create the `Job` after reading the following commands. Those pods like `inventory-scheduler` or `statistics-scheduler` has some labels like `helm.stargate.spaceone.dev/need_initialization!=true`
 
 You should input your aws credentials which have permissions for AWS Secret Mananger in `values.yaml`
 
@@ -24,6 +24,7 @@ You should input your aws credentials which have permissions for AWS Secret Mana
 $ helm repo add spaceone https://helm.stargate.spaceone.dev
 $ helm repo update
 $ helm install sp spaceone/spaceone -f values.yaml
+$ kubectl get pod -n sp -l "helm.stargate.spaceone.dev/need_initialization!=true"
 
 $ sudo kubefwd svc -n default # this command can be replaced with any codes to execute the same job.
 ```

--- a/files/initialize-spaceone.yml
+++ b/files/initialize-spaceone.yml
@@ -4,13 +4,16 @@ metadata:
   name: initialize-spaceone
   namespace: {{ .Release.Namespace }}
   labels:
-  annotations:
+    helm.stargate.spaceone.dev/service: mongo
+{{ include "spaceone.labels" . | indent 4 }}
 spec:
   activeDeadlineSeconds: 300
   template:
     metadata:
       name: "{{ .Release.Name }}"
       labels:
+        helm.stargate.spaceone.dev/service: mongo
+{{ include "spaceone.labels" . | indent 8 }}
     spec:
       restartPolicy: OnFailure
       containers:

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -2,7 +2,9 @@ Thank you for installing SpaceONE Helm Chart.
 
 # How to initialize SpaceONE
 
-1. Wait for microservices to get ready.
+1. Wait for microservices to get ready. (except for the microservices which need initialization)
+
+kubectl get pod -n {{ .Release.Namespace }} -l "helm.stargate.spaceone.dev/need_initialization!=true"
 
 2. Copy and paste the following commands to your terminal.
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -41,6 +41,7 @@ helm.sh/chart: {{ include "spaceone.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{/*
@@ -64,7 +65,7 @@ Create the name of the service account to use
 
 
 {{ define "default-labels" }}
-app: {{ .appName }}
+helm.stargate.spaceone.dev/service: {{ .appName }}
 author: {{ .Values.installedBy.author }}
 {{ end }}
 

--- a/templates/backend/config/config-deployment.yml
+++ b/templates/backend/config/config-deployment.yml
@@ -4,7 +4,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: config
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: config
   name: config
   namespace: {{ .Release.Namespace }}
 spec:
@@ -12,14 +13,15 @@ spec:
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: config
+      helm.stargate.spaceone.dev/service: config
   template:
     metadata:
       annotations:
-        spaceone.config.date: temp-spaceone-data-annotation
         spaceone.auto-deploy-flag: {{ include (print $.Template.BasePath "/backend/identity/identity-conf.yml") . | sha256sum }}
       labels:
-        app: config
+{{ include "spaceone.labels" . | indent 8 }}
+        helm.stargate.spaceone.dev/service: config
+{{ include "spaceone.labels" . | indent 8}}
     spec:
       terminationGracePeriodSeconds: {{ .Values.gracePeriod }}
       containers:

--- a/templates/backend/config/config-svc.yml
+++ b/templates/backend/config/config-svc.yml
@@ -5,7 +5,8 @@ kind: Service
 metadata:
   annotations:
   labels:
-    app: config
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: config
 
   name: config
   namespace: {{ .Release.Namespace }}
@@ -15,7 +16,7 @@ spec:
       port: 50051
       protocol: TCP
   selector:
-    app: config
+    helm.stargate.spaceone.dev/service: config
   sessionAffinity: None
   type: NodePort
 {{ end }}

--- a/templates/backend/identity/identity-deployment.yml
+++ b/templates/backend/identity/identity-deployment.yml
@@ -4,7 +4,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: identity
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: identity
   name: identity
   namespace: {{ .Release.Namespace }}
 spec:
@@ -12,15 +13,14 @@ spec:
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: identity
+      helm.stargate.spaceone.dev/service: identity
   template:
     metadata:
       annotations:
-        spaceone.identity.date: temp-spaceone-data-annotation
-#        spaceone.auto-roll-flag: {{ randAlphaNum 6 | quote }}
         spaceone.auto-deploy-flag: {{ include (print $.Template.BasePath "/backend/identity/identity-conf.yml") . | sha256sum }}
       labels:
-        app: identity
+{{ include "spaceone.labels" . | indent 8 }}
+        helm.stargate.spaceone.dev/service: identity
     spec:
       terminationGracePeriodSeconds: {{ .Values.gracePeriod }}
       containers:

--- a/templates/backend/identity/identity-svc.yml
+++ b/templates/backend/identity/identity-svc.yml
@@ -5,7 +5,8 @@ kind: Service
 metadata:
   annotations:
   labels:
-    app: identity
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: identity
   name: identity
   namespace: {{ .Release.Namespace }}
 spec:
@@ -14,7 +15,7 @@ spec:
       port: 50051
       protocol: TCP
   selector:
-    app: identity
+    helm.stargate.spaceone.dev/service: identity
   sessionAffinity: None
   type: NodePort
 {{ end }}

--- a/templates/backend/inventory-scheduler/inventory-scheduler-deployment.yml
+++ b/templates/backend/inventory-scheduler/inventory-scheduler-deployment.yml
@@ -4,7 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: inventory-scheduler
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: inventory-scheduler
+    helm.stargate.spaceone.dev/need_initialization: "true"
   name: inventory-scheduler
   namespace: {{ .Release.Namespace }}
 spec:
@@ -12,14 +14,15 @@ spec:
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: inventory-scheduler
+      helm.stargate.spaceone.dev/service: inventory-scheduler
   template:
     metadata:
       annotations:
-        spaceone.inventory.date: temp-spaceone-data-annotation
         spaceone.auto-deploy-flag: {{ include (print $.Template.BasePath "/backend/inventory-scheduler/inventory-scheduler-conf.yml") . | sha256sum }}
       labels:
-        app: inventory-scheduler
+{{ include "spaceone.labels" . | indent 8 }}
+        helm.stargate.spaceone.dev/service: inventory-scheduler
+        helm.stargate.spaceone.dev/need_initialization: "true"
     spec:
       terminationGracePeriodSeconds: {{ .Values.gracePeriod }}
       containers:

--- a/templates/backend/inventory-scheduler/inventory-scheduler-svc.yml
+++ b/templates/backend/inventory-scheduler/inventory-scheduler-svc.yml
@@ -5,7 +5,8 @@ kind: Service
 metadata:
   annotations:
   labels:
-    app: inventory-scheduler
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: inventory-scheduler
   name: inventory-scheduler
   namespace: {{ .Release.Namespace }}
 spec:
@@ -14,7 +15,7 @@ spec:
       port: 50051
       protocol: TCP
   selector:
-    app: inventory-scheduler
+    helm.stargate.spaceone.dev/service: inventory-scheduler
   sessionAffinity: None
   type: NodePort
 {{ end }}

--- a/templates/backend/inventory-worker/inventory-worker-deployment.yml
+++ b/templates/backend/inventory-worker/inventory-worker-deployment.yml
@@ -4,7 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: inventory-worker
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: inventory-worker
+    helm.stargate.spaceone.dev/need_initialization: "true"
   name: inventory-worker
   namespace: {{ .Release.Namespace }}
 spec:
@@ -12,14 +14,14 @@ spec:
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: inventory-worker
+      helm.stargate.spaceone.dev/service: inventory-worker
   template:
     metadata:
       annotations:
-        spaceone.inventory.date: temp-spaceone-data-annotation
         spaceone.auto-deploy-flag: {{ include (print $.Template.BasePath "/backend/inventory-worker/inventory-worker-conf.yml") . | sha256sum }}
       labels:
-        app: inventory-worker
+{{ include "spaceone.labels" . | indent 8 }}
+        helm.stargate.spaceone.dev/service: inventory-worker
     spec:
       terminationGracePeriodSeconds: {{ .Values.gracePeriod }}
       containers:

--- a/templates/backend/inventory-worker/inventory-worker-svc.yml
+++ b/templates/backend/inventory-worker/inventory-worker-svc.yml
@@ -5,7 +5,8 @@ kind: Service
 metadata:
   annotations:
   labels:
-    app: inventory-worker
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: inventory-worker
   name: inventory-worker
   namespace: {{ .Release.Namespace }}
 spec:
@@ -14,7 +15,7 @@ spec:
       port: 50051
       protocol: TCP
   selector:
-    app: inventory-worker
+    helm.stargate.spaceone.dev/service: inventory-worker
   sessionAffinity: None
   type: NodePort
 {{ end }}

--- a/templates/backend/inventory/inventory-deployment.yml
+++ b/templates/backend/inventory/inventory-deployment.yml
@@ -4,7 +4,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: inventory
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: inventory
   name: inventory
   namespace: {{ .Release.Namespace }}
 spec:
@@ -12,14 +13,14 @@ spec:
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: inventory
+      helm.stargate.spaceone.dev/service: inventory
   template:
     metadata:
       annotations:
-        spaceone.inventory.date: temp-spaceone-data-annotation
         spaceone.auto-deploy-flag: {{ include (print $.Template.BasePath "/backend/inventory/inventory-conf.yml") . | sha256sum }}
       labels:
-        app: inventory
+{{ include "spaceone.labels" . | indent 8 }}
+        helm.stargate.spaceone.dev/service: inventory
     spec:
       terminationGracePeriodSeconds: {{ .Values.gracePeriod }}
       containers:

--- a/templates/backend/inventory/inventory-svc.yml
+++ b/templates/backend/inventory/inventory-svc.yml
@@ -5,7 +5,8 @@ kind: Service
 metadata:
   annotations:
   labels:
-    app: inventory
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: inventory
   name: inventory
   namespace: {{ .Release.Namespace }}
 spec:
@@ -14,7 +15,7 @@ spec:
       port: 50051
       protocol: TCP
   selector:
-    app: inventory
+    helm.stargate.spaceone.dev/service: inventory
   sessionAffinity: None
   type: NodePort
 {{ end }}

--- a/templates/backend/monitoring/monitoring-deployment.yml
+++ b/templates/backend/monitoring/monitoring-deployment.yml
@@ -4,7 +4,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: monitoring
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: monitoring
   name: monitoring
   namespace: {{ .Release.Namespace }}
 spec:
@@ -12,14 +13,14 @@ spec:
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: monitoring
+      helm.stargate.spaceone.dev/service: monitoring
   template:
     metadata:
       annotations:
-        spaceone.monitoring.date: temp-spaceone-data-annotation
         spaceone.auto-deploy-flag: {{ include (print $.Template.BasePath "/backend/monitoring/monitoring-conf.yml") . | sha256sum }}
       labels:
-        app: monitoring
+{{ include "spaceone.labels" . | indent 8 }}
+        helm.stargate.spaceone.dev/service: monitoring
     spec:
       terminationGracePeriodSeconds: {{ .Values.gracePeriod }}
       containers:

--- a/templates/backend/monitoring/monitoring-svc.yml
+++ b/templates/backend/monitoring/monitoring-svc.yml
@@ -5,7 +5,8 @@ kind: Service
 metadata:
   annotations:
   labels:
-    app: monitoring
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: monitoring
   name: monitoring
   namespace: {{ .Release.Namespace }}
 spec:
@@ -14,7 +15,7 @@ spec:
       port: 50051
       protocol: TCP
   selector:
-    app: monitoring
+    helm.stargate.spaceone.dev/service: monitoring
   sessionAffinity: None
   type: NodePort
 {{ end }}

--- a/templates/backend/plugin/plugin-deployment.yml
+++ b/templates/backend/plugin/plugin-deployment.yml
@@ -4,7 +4,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: plugin
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: plugin
   name: plugin
   namespace: {{ .Release.Namespace }}
 spec:
@@ -12,14 +13,14 @@ spec:
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: plugin
+      helm.stargate.spaceone.dev/service: plugin
   template:
     metadata:
       annotations:
-        spaceone.plugin.date: temp-spaceone-data-annotation
         spaceone.auto-deploy-flag: {{ include (print $.Template.BasePath "/backend/plugin/plugin-conf.yml") . | sha256sum }}
       labels:
-        app: plugin
+{{ include "spaceone.labels" . | indent 8 }}
+        helm.stargate.spaceone.dev/service: plugin
     spec:
       terminationGracePeriodSeconds: {{ .Values.gracePeriod }}
       containers:

--- a/templates/backend/plugin/plugin-svc.yml
+++ b/templates/backend/plugin/plugin-svc.yml
@@ -5,7 +5,8 @@ kind: Service
 metadata:
   annotations:
   labels:
-    app: plugin
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: plugin
   name: plugin
   namespace: {{ .Release.Namespace }}
 spec:
@@ -14,7 +15,7 @@ spec:
       port: 50051
       protocol: TCP
   selector:
-    app: plugin
+    helm.stargate.spaceone.dev/service: plugin
   sessionAffinity: None
   type: NodePort
 {{ end }}

--- a/templates/backend/repository/repository-deployment.yml
+++ b/templates/backend/repository/repository-deployment.yml
@@ -4,7 +4,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: repository
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: repository
   name: repository
   namespace: {{ .Release.Namespace }}
 spec:
@@ -12,14 +13,14 @@ spec:
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: repository
+      helm.stargate.spaceone.dev/service: repository
   template:
     metadata:
       annotations:
-        spaceone.repository.date: temp-spaceone-data-annotation
         spaceone.auto-deploy-flag: {{ include (print $.Template.BasePath "/backend/repository/repository-conf.yml") . | sha256sum }}
       labels:
-        app: repository
+{{ include "spaceone.labels" . | indent 8 }}
+        helm.stargate.spaceone.dev/service: repository
     spec:
       terminationGracePeriodSeconds: {{ .Values.gracePeriod }}
       containers:

--- a/templates/backend/repository/repository-svc.yml
+++ b/templates/backend/repository/repository-svc.yml
@@ -5,7 +5,8 @@ kind: Service
 metadata:
   annotations:
   labels:
-    app: repository
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: repository
   name: repository
   namespace: {{ .Release.Namespace }}
 spec:
@@ -14,7 +15,7 @@ spec:
       port: 50051
       protocol: TCP
   selector:
-    app: repository
+    helm.stargate.spaceone.dev/service: repository
   sessionAffinity: None
   type: NodePort
 {{ end }}

--- a/templates/backend/secret/secret-deployment.yml
+++ b/templates/backend/secret/secret-deployment.yml
@@ -4,7 +4,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: secret
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: secret
   name: secret
   namespace: {{ .Release.Namespace }}
 spec:
@@ -12,14 +13,14 @@ spec:
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: secret
+      helm.stargate.spaceone.dev/service: secret
   template:
     metadata:
       annotations:
-        spaceone.secret.date: temp-spaceone-data-annotation
         spaceone.auto-deploy-flag: {{ include (print $.Template.BasePath "/backend/secret/secret-conf.yml") . | sha256sum }}
       labels:
-        app: secret
+{{ include "spaceone.labels" . | indent 8 }}
+        helm.stargate.spaceone.dev/service: secret
     spec:
       terminationGracePeriodSeconds: {{ .Values.gracePeriod }}
       containers:

--- a/templates/backend/secret/secret-svc.yml
+++ b/templates/backend/secret/secret-svc.yml
@@ -5,7 +5,8 @@ kind: Service
 metadata:
   annotations:
   labels:
-    app: secret
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: secret
   name: secret
   namespace: {{ .Release.Namespace }}
 spec:
@@ -14,7 +15,7 @@ spec:
       port: 50051
       protocol: TCP
   selector:
-    app: secret
+    helm.stargate.spaceone.dev/service: secret
   sessionAffinity: None
   type: NodePort
 {{ end }}

--- a/templates/backend/statistics-scheduler/statistics-scheduler-deployment.yml
+++ b/templates/backend/statistics-scheduler/statistics-scheduler-deployment.yml
@@ -4,7 +4,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: statistics-scheduler
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: statistics-scheduler
+    helm.stargate.spaceone.dev/need_initialization: "true"
   name: statistics-scheduler
   namespace: {{ .Release.Namespace }}
 spec:
@@ -12,14 +14,15 @@ spec:
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: statistics-scheduler
+      helm.stargate.spaceone.dev/service: statistics-scheduler
   template:
     metadata:
       annotations:
-        spaceone.statistics.date: temp-spaceone-data-annotation
         spaceone.auto-deploy-flag: {{ include (print $.Template.BasePath "/backend/statistics-scheduler/statistics-scheduler-conf.yml") . | sha256sum }}
       labels:
-        app: statistics-scheduler
+{{ include "spaceone.labels" . | indent 8 }}
+        helm.stargate.spaceone.dev/service: statistics-scheduler
+        helm.stargate.spaceone.dev/need_initialization: "true"
     spec:
       terminationGracePeriodSeconds: {{ .Values.gracePeriod }}
       containers:

--- a/templates/backend/statistics-scheduler/statistics-scheduler-svc.yml
+++ b/templates/backend/statistics-scheduler/statistics-scheduler-svc.yml
@@ -5,7 +5,8 @@ kind: Service
 metadata:
   annotations:
   labels:
-    app: statistics-scheduler
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: statistics-scheduler
   name: statistics-scheduler
   namespace: {{ .Release.Namespace }}
 spec:
@@ -14,7 +15,7 @@ spec:
       port: 50051
       protocol: TCP
   selector:
-    app: statistics-scheduler
+    helm.stargate.spaceone.dev/service: statistics-scheduler
   sessionAffinity: None
   type: NodePort
 {{ end }}

--- a/templates/backend/statistics/statistics-deployment.yml
+++ b/templates/backend/statistics/statistics-deployment.yml
@@ -4,7 +4,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: statistics
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: statistics
   name: statistics
   namespace: {{ .Release.Namespace }}
 spec:
@@ -12,14 +13,14 @@ spec:
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: statistics
+      helm.stargate.spaceone.dev/service: statistics
   template:
     metadata:
       annotations:
-        spaceone.statistics.date: temp-spaceone-data-annotation
         spaceone.auto-deploy-flag: {{ include (print $.Template.BasePath "/backend/statistics/statistics-conf.yml") . | sha256sum }}
       labels:
-        app: statistics
+{{ include "spaceone.labels" . | indent 8 }}
+        helm.stargate.spaceone.dev/service: statistics
     spec:
       terminationGracePeriodSeconds: {{ .Values.gracePeriod }}
       containers:

--- a/templates/backend/statistics/statistics-svc.yml
+++ b/templates/backend/statistics/statistics-svc.yml
@@ -5,7 +5,8 @@ kind: Service
 metadata:
   annotations:
   labels:
-    app: statistics
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: statistics
   name: statistics
   namespace: {{ .Release.Namespace }}
 spec:
@@ -14,7 +15,7 @@ spec:
       port: 50051
       protocol: TCP
   selector:
-    app: statistics
+    helm.stargate.spaceone.dev/service: statistics
   sessionAffinity: None
   type: NodePort
 {{ end }}

--- a/templates/consul/deployment.yml
+++ b/templates/consul/deployment.yml
@@ -4,17 +4,19 @@ kind: Deployment
 metadata:
   name: consul
   labels:
-    app: consul
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: consul
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1 # multiple pod for minimum HA
   selector:
     matchLabels:
-      app: consul
+      helm.stargate.spaceone.dev/service: consul
   template:
     metadata:
       labels:
-        app: consul
+{{ include "spaceone.labels" . | indent 8 }}
+        helm.stargate.spaceone.dev/service: consul
     spec:
       volumes:
       - name: consul-data

--- a/templates/consul/svc.yml
+++ b/templates/consul/svc.yml
@@ -4,7 +4,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: consul
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: consul
   name: consul
   namespace: {{ .Release.Namespace }}
 spec:
@@ -20,5 +21,5 @@ spec:
       targetPort: 8500
       protocol: TCP
   selector:
-    app: consul
+    helm.stargate.spaceone.dev/service: consul
 {{ end }}

--- a/templates/frontend/wconsole-client/wconsole-client-deployment.yml
+++ b/templates/frontend/wconsole-client/wconsole-client-deployment.yml
@@ -4,7 +4,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: console-client
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: console-client
   name: console-client
   namespace: {{ .Release.Namespace }}
 spec:
@@ -12,14 +13,14 @@ spec:
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: console-client
+      helm.stargate.spaceone.dev/service: console-client
   template:
     metadata:
       annotations:
-        spaceone.consoleclient.date: temp-spaceone-data-annotation
         spaceone.auto-deploy-flag: {{ include (print $.Template.BasePath "/frontend/wconsole-client/wconsole-client-spa-conf.yml") . | sha256sum }}
       labels:
-        app: console-client
+{{ include "spaceone.labels" . | indent 8 }}
+        helm.stargate.spaceone.dev/service: console-client
     spec:
       terminationGracePeriodSeconds: {{ .Values.gracePeriod }}
       containers:

--- a/templates/frontend/wconsole-client/wconsole-client-svc.yml
+++ b/templates/frontend/wconsole-client/wconsole-client-svc.yml
@@ -5,7 +5,8 @@ kind: Service
 metadata:
   annotations:
   labels:
-    app: console-client
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: console-client
   name: console-client
   namespace: {{ .Release.Namespace }}
 spec:
@@ -15,7 +16,7 @@ spec:
       targetPort: 80
       nodePort: 32374
   selector:
-    app: console-client
+    helm.stargate.spaceone.dev/service: console-client
   sessionAffinity: None
   type: NodePort
 
@@ -26,7 +27,8 @@ kind: Service
 metadata:
   annotations:
   labels:
-    app: console-client
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: console-client
   name: root
   namespace: {{ .Release.Namespace }}
 spec:
@@ -36,7 +38,7 @@ spec:
       targetPort: 80
       nodePort: 31761
   selector:
-    app: console-client
+    helm.stargate.spaceone.dev/service: console-client
   sessionAffinity: None
   type: NodePort
 {{ end }}

--- a/templates/frontend/wconsole-server/wconsole-server-deployment.yml
+++ b/templates/frontend/wconsole-server/wconsole-server-deployment.yml
@@ -6,20 +6,21 @@ metadata:
   name: console-server
   namespace: {{ .Release.Namespace }}
   labels:
-    app: console-server
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: console-server
 spec:
   replicas: {{ .Values.frontend.replicas }}
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: console-server
+      helm.stargate.spaceone.dev/service: console-server
   template:
     metadata:
       annotations:
-        spaceone.consoleserver.date: temp-spaceone-data-annotation
         spaceone.auto-deploy-flag: {{ include (print $.Template.BasePath "/frontend/wconsole-server/wconsole-server-nginx-conf.yml") . | sha256sum }}
       labels:
-        app: console-server
+{{ include "spaceone.labels" . | indent 8 }}
+        helm.stargate.spaceone.dev/service: console-server
     spec:
       terminationGracePeriodSeconds: {{ .Values.gracePeriod }}
       containers:

--- a/templates/frontend/wconsole-server/wconsole-server-svc.yml
+++ b/templates/frontend/wconsole-server/wconsole-server-svc.yml
@@ -5,7 +5,8 @@ kind: Service
 metadata:
   annotations:
   labels:
-    app: console-server
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: console-server
   name: console-server
   namespace: {{ .Release.Namespace }}
 spec:
@@ -15,7 +16,7 @@ spec:
       targetPort: 80
       nodePort: 31760
   selector:
-    app: console-server
+    helm.stargate.spaceone.dev/service: console-server
   sessionAffinity: None
   type: NodePort
 {{ end }}

--- a/templates/helm-syntax-examples/_deployment.yaml
+++ b/templates/helm-syntax-examples/_deployment.yaml
@@ -4,6 +4,7 @@ kind: Deployment
 metadata:
   name: {{ include "spaceone.fullname" . }}
   labels:
+{{ include "spaceone.labels" . | indent 4 }}
     {{- include "spaceone.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
@@ -13,6 +14,7 @@ spec:
   template:
     metadata:
       labels:
+{{ include "spaceone.labels" . | indent 8 }}
         {{- include "spaceone.selectorLabels" . | nindent 8 }}
     spec:
     {{- with .Values.imagePullSecrets }}

--- a/templates/helm-syntax-examples/_ingress.yaml
+++ b/templates/helm-syntax-examples/_ingress.yaml
@@ -12,6 +12,7 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
+{{ include "spaceone.labels" . | indent 4 }}
     {{- include "spaceone.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:

--- a/templates/helm-syntax-examples/_service.yaml
+++ b/templates/helm-syntax-examples/_service.yaml
@@ -4,6 +4,7 @@ kind: Service
 metadata:
   name: {{ include "spaceone.fullname" . }}
   labels:
+{{ include "spaceone.labels" . | indent 4 }}
     {{- include "spaceone.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}

--- a/templates/helm-syntax-examples/_serviceaccount.yaml
+++ b/templates/helm-syntax-examples/_serviceaccount.yaml
@@ -4,6 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "spaceone.serviceAccountName" . }}
   labels:
+{{ include "spaceone.labels" . | indent 4 }}
     {{- include "spaceone.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:

--- a/templates/mongo/deployment.yaml
+++ b/templates/mongo/deployment.yaml
@@ -3,7 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: mongo
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: mongo
   name: mongo
   namespace: {{ .Release.Namespace }}
 spec:
@@ -11,14 +12,14 @@ spec:
   revisionHistoryLimit: {{ .Values.backend.revisionHistoryLimit | int }}
   selector:
     matchLabels:
-      app: mongo
+      helm.stargate.spaceone.dev/service: mongo
   template:
     metadata:
       annotations:
         spaceone.auto-deploy-flag: {{ include (print $.Template.BasePath "/mongo/conf.yml") . | sha256sum }}
-#        spaceone.identity.date: temp-spaceone-data-annotation
       labels:
-        app: mongo
+{{ include "spaceone.labels" . | indent 8 }}
+        helm.stargate.spaceone.dev/service: mongo
     spec:
       terminationGracePeriodSeconds: {{ .Values.gracePeriod }}
       containers:

--- a/templates/mongo/initialize-job-conf.yml
+++ b/templates/mongo/initialize-job-conf.yml
@@ -9,4 +9,4 @@ data:
   # kubectl get cm initialize-spaceone-conf -o 'go-template={{ `{{index .data "initialize-spaceone.yml"}}` }}'
   # and can apply the output
   initialize-spaceone.yml: |
-{{ tpl (.Files.Get "files/initialize-spaceone.yml") . | indent 4}}
+{{ tpl (.Files.Get "files/initialize-spaceone.yml") . | indent 4 }}

--- a/templates/mongo/svc.yml
+++ b/templates/mongo/svc.yml
@@ -3,7 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: mongo
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: mongo
   name: mongo
   namespace: {{ .Release.Namespace }}
 spec:
@@ -11,7 +12,7 @@ spec:
     - port: {{ .Values.mongo.port }}
       protocol: TCP
   selector:
-    app: mongo
+    helm.stargate.spaceone.dev/service: mongo
   sessionAffinity: None
   type: NodePort
 {{ end }}

--- a/templates/redis/redis-deployment.yml
+++ b/templates/redis/redis-deployment.yml
@@ -5,16 +5,18 @@ metadata:
   name: redis
   namespace: {{ .Release.Namespace }}
   labels:
-    app: redis
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: redis
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: redis
+      helm.stargate.spaceone.dev/service: redis
   template:
     metadata:
       labels:
-        app: redis
+{{ include "spaceone.labels" . | indent 8 }}
+        helm.stargate.spaceone.dev/service: redis
     spec:
       terminationGracePeriodSeconds: {{ .Values.gracePeriod }}
       containers:
@@ -40,6 +42,7 @@ metadata:
   name: redis
   namespace: {{ .Release.Namespace }}
   labels:
+{{ include "spaceone.labels" . | indent 4 }}
     run: redis
 spec:
   type: NodePort
@@ -49,5 +52,5 @@ spec:
     nodePort: 31357
     protocol: TCP
   selector:
-    app: redis
+    helm.stargate.spaceone.dev/service: redis
 {{ end }}

--- a/templates/supervisor/supervisor/supervisor-deployment.yml
+++ b/templates/supervisor/supervisor/supervisor-deployment.yml
@@ -3,7 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: supervisor
+{{ include "spaceone.labels" . | indent 4 }}
+    helm.stargate.spaceone.dev/service: supervisor
   name: supervisor
   namespace: '{{ .Release.Namespace }}'
 spec:
@@ -11,14 +12,15 @@ spec:
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: supervisor
+      helm.stargate.spaceone.dev/service: supervisor
   template:
     metadata:
       annotations:
 #        spaceone.supervisor.date: ${new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z").format(new java.util.Date())}
         spaceone.auto-deploy-flag: {{ include (print $.Template.BasePath "/supervisor/supervisor/supervisor-conf.yml") . | sha256sum }}
       labels:
-        app: supervisor
+{{ include "spaceone.labels" . | indent 8 }}
+        helm.stargate.spaceone.dev/service: supervisor
     spec:
       terminationGracePeriodSeconds: {{ .Values.gracePeriod }}
       serviceAccountName: supervisor

--- a/values.yaml
+++ b/values.yaml
@@ -131,10 +131,10 @@ supervisor:
 #######
 # Vault reference : https://www.vaultproject.io/docs/platform/k8s/helm/configuration
 #######
-vault:
-  global:
-    enabled: true
-  server:
-    dev:
-      enabled: true
-  name: hello
+#vault:
+#  global:
+#    enabled: true
+#  server:
+#    dev:
+#      enabled: true
+#  name: hello


### PR DESCRIPTION
Use a helm template named `spaceone.labels` to label.

```
app.kubernetes.io/instance=sp
app.kubernetes.io/managed-by=Helm
app.kubernetes.io/name=spaceone
app.kubernetes.io/version=1.1.0
helm.sh/chart=spaceone-0.1.2
helm.stargate.spaceone.dev/service=identity
```

Use a label which shows its dependency on initalization.

> These servicecs need initialization.
```
helm.stargate.spaceone.dev/need_initialization=true
```


